### PR TITLE
投稿編集（空投稿防止・文字数制限）

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,7 +10,13 @@ class CommentsController < ApplicationController
 
     def create
       @comment = Comment.create params.require(:comment).permit(:content, :image) # POINT
-      redirect_to @comment
+      if @comment.save
+        flash[:notice]= "投稿しました"
+        redirect_to("/comments")
+      else
+        flash[:notice]= "投稿に失敗しました"
+        redirect_to("/comments/new")
+      end
     end
 
     def show
@@ -33,7 +39,11 @@ class CommentsController < ApplicationController
     def update
       @comment = Comment.find(params[:id])
       @comment.content = params[:content]
-      @comment.save
-      redirect_to("/comments")
+      if @comment.save
+        flash[:notice]= "投稿を編集しました"
+          redirect_to("/comments")
+        else
+          render("comments/edit")
+      end
     end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,4 @@
 class Comment < ApplicationRecord
     has_one_attached :image
+    validates :content, {presence: true,length:{maximum: 140}}
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,6 +37,12 @@
 
         </ul>
     </div>
+
+    <% if flash[:notice]%>
+      <div class="flash">
+        <%= flash[:notice]%>
+      </div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get "comments" => "comments#index"
   get "comments/:id" => "comments#show"
   get "comments/new" =>"comments#new"
-  get "comments/:id" => "comments#edit"
+  get "comments/:id/edit" => "comments#edit"
   delete "commnets/:id" => "comments#destroy"
   post "comments/:id" => "comments#update"
 


### PR DESCRIPTION
★変更目的★
投稿をする際に、空投稿が出来る、文字数関係なく投稿が出来る。
その為、「日常をつぶやく」をテーマにしたサイトから離れる。


★変更内容★
変更内容の詳細やポイントとなる部分について記載します。
（コードブロックや画像添付等を積極的に活用してまとめると理解を深める＆共有化にも繋がるかと思います）

_⭐️ポイント1. _
<img width="1113" alt="スクリーンショット 2019-12-25 23 40 29" src="https://user-images.githubusercontent.com/54671960/71447375-f648ad80-2770-11ea-9be8-a16934ca398e.png">
投稿、削除、編集した際に、flashが表示されるようにしました！

_⭐️ポイント2. _

空投稿防止！（空投稿：投稿の文字数が０の時）

_⭐️ポイント3. _

投稿の際に140文字数制限しました！

・文字数が140文字超えた時のリンク先
ー新規投稿（new）：新規投稿画面が表示
ー投稿編集（edit）：編集画面が表示＆前に投稿した内容を表示


