### PR TITLE
Feature/issue #19

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,7 @@
 class CommentsController < ApplicationController
     def index
       @comment = Comment.all.order(created_at: :desc)
-      @user = current_user
+      @user = User.find_by(params[:id])
     end
 
     def new
@@ -9,7 +9,7 @@ class CommentsController < ApplicationController
     end
 
     def create
-      @comment = Comment.create params.require(:comment).permit(:content, :image) # POINT
+      @comment = Comment.create params.require(:comment).permit(:content, :image,).merge(user_id: current_user.id)
       if @comment.save
         flash[:notice]= "投稿しました"
         redirect_to("/comments")
@@ -21,7 +21,7 @@ class CommentsController < ApplicationController
 
     def show
       @comment = Comment.find(params[:id])
-      @user = current_user
+      @user = User.find_by(id: @comment.user_id)
     end
 
     def edit

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,7 @@
 class CommentsController < ApplicationController
     def index
       @comment = Comment.all.order(created_at: :desc)
-      @user = User.find_by(params[:id])
+      @user = current_user
     end
 
     def new

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,7 @@
 class CommentsController < ApplicationController
     def index
       @comment = Comment.all.order(created_at: :desc)
-      @user = current_user
+
     end
 
     def new

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,4 +2,5 @@ class Comment < ApplicationRecord
     has_one_attached :image
     validates :content, {presence: true,length:{maximum: 140}}
 
+    belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,6 @@ class User < ApplicationRecord
     has_one_attached :image
     devise :database_authenticatable, :registerable,
             :recoverable, :rememberable, :validatable
+
+
 end

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -16,11 +16,12 @@
                     <% if user_signed_in? %>
                         <div class='row left'>
                             <div class='col s12 m12'>
+                            <!--プロフ画像-->
                             <% if @user.image.attached? %>
                                 <%= link_to image_tag(@user.image, class: "me_image"), "/comments/#{comment.id}" %>
-                                <% else %>
+                            <% else %>
                                 <%= image_tag '/defalt_img.png',class: 'defalt_img'%>
-                                <%end%>
+                            <%end%>
                             </div>
                         </div>
                     <% end %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -17,18 +17,23 @@
                         <div class='row left'>
                             <div class='col s12 m12'>
                             <!--プロフ画像-->
-                            <% if @user.image.attached? %>
-                                <%= link_to image_tag(@user.image, class: "me_image"), "/comments/#{comment.id}" %>
+                            <% if comment.user.image.attached? %>
+                                <%= link_to image_tag(comment.user.image, class: "me_image"), "/comments/#{comment.id}" %>
                             <% else %>
                                 <%= image_tag '/defalt_img.png',class: 'defalt_img'%>
                             <%end%>
+                            <%= comment.user.name%>
                             </div>
                         </div>
                     <% end %>
 
                         <div class='row'>
                             <div class='col s12 m12 '>
-                                <%= link_to(comment.content,"/comments/#{comment.id}",class: "link")%>
+                                <% if user_signed_in? %>
+                                    <%= link_to(comment.content,"/comments/#{comment.id}",class: "link")%>
+                                <% else %>
+                                <%= link_to(comment.content,new_user_session_path, class: "link")%>
+                                <% end %>
                             </div>
                         </div>
                         <div class='row'>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -21,9 +21,13 @@
         <div class='row'>
               <%= form.file_field :image ,class:"new_image"%><br>
         </div>
-        <button class="btn waves-effect waves-light" type="submit" name="action">つぶやく
-          <i class="material-icons right">send</i>
-        </button>
+        <% if user_signed_in? %>
+          <button class="btn waves-effect waves-light" type="submit" name="action">つぶやく
+            <i class="material-icons right">send</i>
+          </button>
+        <% else %>
+        <%= link_to("つぶやく", new_user_session_path, class:"btn") %>
+        <% end %>
       <% end %>
       </div>
     </div>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -12,6 +12,7 @@
                             <% else %>
                                 <%= image_tag '/defalt_img.png',class: 'defalt_img'%>
                             <%end%>
+                            <%= @user.name%>
                             </div>
                         </div>
                     <% end %>
@@ -40,8 +41,10 @@
         <div class='row center'>
               <div class='col s12'>
                   <%= link_to("戻る","/comments/",class:"btn back") %>
-                  <%= link_to("編集","/comments/#{@comment.id}/edit",class:"btn edit")%>
-                  <%= link_to("削除","/comments/#{@comment.id}",method:"delete",class:'btn delete')%>
+                  <% if @user.id == current_user.id %>
+                    <%= link_to("編集","/comments/#{@comment.id}/edit",class:"btn edit")%>
+                    <%= link_to("削除","/comments/#{@comment.id}",method:"delete",class:'btn delete')%>
+                  <% end %>
               </div>
         </div>
 

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -41,9 +41,11 @@
         <div class='row center'>
               <div class='col s12'>
                   <%= link_to("戻る","/comments/",class:"btn back") %>
-                  <% if @user.id == current_user.id %>
-                    <%= link_to("編集","/comments/#{@comment.id}/edit",class:"btn edit")%>
-                    <%= link_to("削除","/comments/#{@comment.id}",method:"delete",class:'btn delete')%>
+                  <% if user_signed_in? %>
+                    <% if @user.id == current_user.id %>
+                        <%= link_to("編集","/comments/#{@comment.id}/edit",class:"btn edit")%>
+                        <%= link_to("削除","/comments/#{@comment.id}",method:"delete",class:'btn delete')%>
+                    <% end %>
                   <% end %>
               </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,8 +17,9 @@
       <a href="/" class="brand-logo">TWEETO WORLD!</a>
       <ul id="nav-mobile" class="right hide-on-med-and-down">
         <li><a href="/comments/new">つぶやく</a></li>
-        <% if user_signed_in? %>
         <li><a href="/comments/">みんなのなう</a></li>
+        <% if user_signed_in? %>
+
         <li><a href="/me">プロフィール</a></li>
           <li><%= link_to('ログアウト', destroy_user_session_path, method: :delete) %></li>
             </a></li>


### PR DESCRIPTION
#21 issueはこちら

# 変更点
### ①ログイン前
<img width="1280" alt="スクリーンショット 2020-01-19 12 30 31" src="https://user-images.githubusercontent.com/54671960/72674264-e4c89c00-3ab7-11ea-8ed7-d91d7ba6179e.png">
・ログインせずにみんなのなう（投稿）が閲覧可能
・つぶやくページまで見れるが実際につぶやくとなるとログイン画面表示。
→理由：ある程度触ることが出来、実際にもっと知りたいと思った時に会員登録する流れを作るため。

### ②ログイン後
・〈みんなのなう〉投稿主のアイコン・名前の表示
before
<img width="877" alt="スクリーンショット 2020-01-19 12 37 05" src="https://user-images.githubusercontent.com/54671960/72674313-733d1d80-3ab8-11ea-8d3a-93fbeabbce76.png">

after
<img width="886" alt="スクリーンショット 2020-01-19 12 32 44" src="https://user-images.githubusercontent.com/54671960/72674293-530d5e80-3ab8-11ea-9062-76ef6fde9894.png">

・〈詳細画面〉投稿主以外は投稿の編集・削除を表示させない。
<img width="918" alt="スクリーンショット 2020-01-19 12 38 17" src="https://user-images.githubusercontent.com/54671960/72674375-e8105780-3ab8-11ea-9c19-dd66c46170aa.png">
↑他の人の投稿の場合
<img width="895" alt="スクリーンショット 2020-01-19 12 38 32" src="https://user-images.githubusercontent.com/54671960/72674377-eba3de80-3ab8-11ea-93d6-45235cae24ee.png">
↑自分（ログイン中のアカウント）の場合
